### PR TITLE
Bump minimum Python supported to 3.9, fix test clean up

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         py-version: [
-          "3.8",
           "3.9",
           "3.10",
           "3.11",
           "3.12",
+          "3.13",
         ]
         os: [
           "ubuntu-latest",
@@ -29,21 +29,21 @@ jobs:
         ]
         exclude:
           - os: windows-latest
-            py-version: "3.9"
-          - os: windows-latest
             py-version: "3.10"
           - os: windows-latest
             py-version: "3.11"
           - os: windows-latest
             py-version: "3.12"
-          - os: macos-latest
-            py-version: "3.9"
+          - os: windows-latest
+            py-version: "3.13"
           - os: macos-latest
             py-version: "3.10"
           - os: macos-latest
             py-version: "3.11"
           - os: macos-latest
             py-version: "3.12"
+          - os: macos-latest
+            py-version: "3.13"
 
     steps:
       - name: Setup Python 3.x

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: reuse
         name: Check REUSE compatibility
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
         name: Check YAML

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ test-run:
 test-clean:
 ifeq "$(OS)" "Windows_NT"
 	-@subst T: /d
-	-@python scripts/rmdir.py testmount
-	-@python scripts/rmdir.py tests/sandbox/circuitpython
+	-@python scripts\rmdir.py testmount
+	-@python scripts\rmdir.py tests\sandbox\circuitpython
 else ifeq "$(shell uname -s)" "Linux"
 	-@sudo umount testmount
 	-@sudo rm -rf testmount

--- a/circfirm/backend/__init__.py
+++ b/circfirm/backend/__init__.py
@@ -9,7 +9,6 @@ Author(s): Alec Delaney
 
 import enum
 import re
-from typing import Tuple
 
 
 class Language(enum.Enum):
@@ -60,7 +59,7 @@ def get_uf2_filename(board_id: str, version: str, language: str = "en_US") -> st
     return f"adafruit-circuitpython-{board_id}-{language}-{version}.uf2"
 
 
-def parse_firmware_info(uf2_filename: str) -> Tuple[str, str]:
+def parse_firmware_info(uf2_filename: str) -> tuple[str, str]:
     """Get firmware info."""
     regex_match = re.match(FIRMWARE_REGEX, uf2_filename)
     if regex_match is None:

--- a/circfirm/backend/cache.py
+++ b/circfirm/backend/cache.py
@@ -9,8 +9,7 @@ Author(s): Alec Delaney
 
 import os
 import pathlib
-import re
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Optional
 
 import packaging.version
 import requests
@@ -57,12 +56,12 @@ def download_uf2(board_id: str, version: str, language: str = "en_US") -> None:
         uf2file.write(response.content)
 
 
-def get_sorted_boards(board_id: Optional[str]) -> Dict[str, Dict[str, Set[str]]]:
+def get_sorted_boards(board_id: Optional[str]) -> dict[str, dict[str, set[str]]]:
     """Get a sorted collection of boards, versions, and languages."""
-    boards: Dict[str, Dict[str, Set[str]]] = {}
+    boards: dict[str, dict[str, set[str]]] = {}
     for board_folder in sorted(os.listdir(circfirm.UF2_ARCHIVE)):
-        versions: Dict[str, List[str]] = {}
-        sorted_versions: Dict[str, Set[str]] = {}
+        versions: dict[str, list[str]] = {}
+        sorted_versions: dict[str, set[str]] = {}
         if board_id is not None and board_id != board_folder:
             continue
         board_folder_full = get_board_folder(board_folder)

--- a/circfirm/backend/device.py
+++ b/circfirm/backend/device.py
@@ -9,7 +9,7 @@ Author(s): Alec Delaney
 
 import pathlib
 import re
-from typing import Optional, Tuple
+from typing import Optional
 
 import psutil
 
@@ -21,7 +21,7 @@ BOARD_VER_REGEX = (
 )
 
 
-def get_board_info(device_path: str) -> Tuple[str, str]:
+def get_board_info(device_path: str) -> tuple[str, str]:
     """Get the attached CircuitPytho board's name and version."""
     bootout_file = pathlib.Path(device_path) / circfirm.BOOTOUT_FILE
     with open(bootout_file, encoding="utf-8") as infofile:

--- a/circfirm/backend/github.py
+++ b/circfirm/backend/github.py
@@ -9,7 +9,7 @@ Author(s): Alec Delaney
 
 import datetime
 import re
-from typing import List, Tuple, TypedDict
+from typing import TypedDict
 
 import requests
 
@@ -42,7 +42,7 @@ class GitTreeItem(TypedDict):
     url: str
 
 
-def get_rate_limit() -> Tuple[int, int, datetime.datetime]:
+def get_rate_limit() -> tuple[int, int, datetime.datetime]:
     """Get the rate limit for the GitHub REST endpoint."""
     response = requests.get(
         url="https://api.github.com/rate_limit",
@@ -55,7 +55,7 @@ def get_rate_limit() -> Tuple[int, int, datetime.datetime]:
     return available, total, reset_time
 
 
-def get_board_id_list(token: str) -> List[str]:
+def get_board_id_list(token: str) -> list[str]:
     """Get a list of CircuitPython boards."""
     boards = set()
     headers = BASE_REQUESTS_HEADERS.copy()
@@ -69,7 +69,7 @@ def get_board_id_list(token: str) -> List[str]:
         headers=headers,
     )
     try:
-        tree_items: List[GitTreeItem] = response.json()["tree"]
+        tree_items: list[GitTreeItem] = response.json()["tree"]
     except KeyError as err:
         raise ValueError("Could not parse JSON response, check token") from err
     for tree_item in tree_items:

--- a/circfirm/backend/s3.py
+++ b/circfirm/backend/s3.py
@@ -8,7 +8,7 @@ Author(s): Alec Delaney
 """
 
 import re
-from typing import List, Optional
+from typing import Optional
 
 import boto3
 import botocore
@@ -27,7 +27,7 @@ BUCKET = S3_RESOURCE.Bucket(BUCKET_NAME)
 
 def get_board_versions(
     board_id: str, language: str = "en_US", *, regex: Optional[str] = None
-) -> List[str]:
+) -> list[str]:
     """Get a list of CircuitPython versions for a given board."""
     prefix = f"bin/{board_id}/{language}"
     firmware_regex = circfirm.backend.FIRMWARE_REGEX_PATTERN.replace(

--- a/circfirm/cli/__init__.py
+++ b/circfirm/cli/__init__.py
@@ -13,7 +13,8 @@ import pkgutil
 import shutil
 import sys
 import time
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple, TypeVar
+from collections.abc import Iterable
+from typing import Any, Callable, Optional, TypeVar
 
 import click
 import click_spinner
@@ -47,7 +48,7 @@ def get_board_id(
     bootloader: Optional[str],
     board: Optional[str],
     timeout: int = -1,
-) -> Tuple[str, str]:
+) -> tuple[str, str]:
     """Get the board ID of a device via CLI."""
     if not board:
         if not circuitpy and bootloader:
@@ -74,7 +75,7 @@ def get_board_id(
     return bootloader, board
 
 
-def get_connection_status() -> Tuple[Optional[str], Optional[str]]:
+def get_connection_status() -> tuple[Optional[str], Optional[str]]:
     """Get the status of a connectted CircuitPython device as a CIRCUITPY and bootloader location."""
     circuitpy = circfirm.backend.device.find_circuitpy()
     bootloader = circfirm.backend.device.find_bootloader()
@@ -129,7 +130,7 @@ def announce_and_await(
     msg: str,
     func: Callable[..., _T],
     args: Iterable = (),
-    kwargs: Optional[Dict[str, Any]] = None,
+    kwargs: Optional[dict[str, Any]] = None,
     *,
     use_spinner: bool = True,
 ) -> _T:
@@ -154,7 +155,7 @@ def announce_and_await(
         raise err
 
 
-def get_settings() -> Dict[str, Any]:
+def get_settings() -> dict[str, Any]:
     """Get the contents of the settings file."""
     with open(circfirm.SETTINGS_FILE, encoding="utf-8") as yamlfile:
         return yaml.safe_load(yamlfile)

--- a/circfirm/cli/current.py
+++ b/circfirm/cli/current.py
@@ -7,15 +7,13 @@
 Author(s): Alec Delaney
 """
 
-from typing import Tuple
-
 import click
 
 import circfirm.backend.device
 import circfirm.cli
 
 
-def get_board_info() -> Tuple[str, str]:
+def get_board_info() -> tuple[str, str]:
     """Get board info via the CLI."""
     circuitpy, _ = circfirm.cli.get_connection_status()
     if not circuitpy:

--- a/circfirm/startup.py
+++ b/circfirm/startup.py
@@ -10,13 +10,12 @@ Author(s): Alec Delaney
 import os
 import pathlib
 import shutil
-from typing import List, Tuple
 
 import click
 
-FOLDER_LIST: List[str] = []
-FILE_LIST: List[str] = []
-TEMPLATE_LIST: List[Tuple[str, str]] = []
+FOLDER_LIST: list[str] = []
+FILE_LIST: list[str] = []
+TEMPLATE_LIST: list[tuple[str, str]] = []
 
 
 def specify_app_dir(app_name: str) -> str:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,4 +38,3 @@ intersphinx_mapping = {
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = [
 [project]
 name = "circfirm"
 description = "CLI tool for install firmware for CircuitPython boards"
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 readme = "README.rst"
 authors = [
     {name = "Alec Delaney", email = "tekktrik@gmail.com"}
@@ -35,11 +35,11 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Natural Language :: English",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Operating System :: Unix",
     "Operating System :: Microsoft :: Windows",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: MIT
 
-build~=1.0
-coverage~=7.4
-pre-commit~=2.20
-pytest~=8.0
-sphinx~=5.1
+build~=1.2
+coverage~=7.6
+pre-commit~=4.0
+pytest~=8.3
+sphinx~=7.4
 sphinx-tabs~=3.4
-sphinx-rtd-theme~=1.0
+sphinx-rtd-theme~=3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: MIT
 
-boto3~=1.34
-click~=8.0
+boto3~=1.35
+click~=8.1
 click-spinner~=0.1
-packaging~=23.2
-psutil~=5.9
+packaging~=24.2
+psutil~=6.1
 pyyaml~=6.0
-requests~=2.31
-boto3-stubs[essential]~=1.34
+requests~=2.32
+boto3-stubs[essential]~=1.35

--- a/scripts/rmdir.py
+++ b/scripts/rmdir.py
@@ -16,7 +16,7 @@ import sys
 target = sys.argv[1]
 
 for root, dirs, files in os.walk(target):
-    children = dirs.extend(files)
+    children = dirs + files
     for name in children:
         filepath = os.path.join(root, name)
         os.chmod(filepath, 0o777)

--- a/scripts/rmdir.py
+++ b/scripts/rmdir.py
@@ -20,5 +20,5 @@ for root, dirs, files in os.walk(target):
     for name in children:
         filepath = os.path.join(root, name)
         os.chmod(filepath, 0o777)
-        
+
 shutil.rmtree(target)

--- a/scripts/rmdir.py
+++ b/scripts/rmdir.py
@@ -9,8 +9,16 @@ Author(s): Alec Delaney
 
 # pragma: no cover
 
+import os
 import shutil
 import sys
 
 target = sys.argv[1]
+
+for root, dirs, files in os.walk(target):
+    children = dirs.extend(files)
+    for name in children:
+        filepath = os.path.join(root, name)
+        os.chmod(filepath, 0o777)
+        
 shutil.rmtree(target)

--- a/tests/backend/test_backend_s3.py
+++ b/tests/backend/test_backend_s3.py
@@ -9,7 +9,6 @@ Author(s): Alec Delaney
 
 from collections import namedtuple
 from functools import partial
-from typing import List
 
 import boto3.resources.collection
 import pytest
@@ -20,8 +19,8 @@ MockS3Object = namedtuple("MockS3Object", ["key"])
 
 
 def get_fake_s3_objects(
-    board: str, keys: List[str], *args, **kwargs
-) -> List[MockS3Object]:
+    board: str, keys: list[str], *args, **kwargs
+) -> list[MockS3Object]:
     """Create a set of fake S3 objects."""
     template_link = (
         f"bin/{board}/en_US/adafruit-circuitpython-{board}-en_US-[version].uf2"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -12,7 +12,7 @@ import pathlib
 import platform
 import shutil
 import time
-from typing import Any, Callable, Dict, List, TypeVar
+from typing import Any, Callable, TypeVar
 
 import pytest
 import yaml
@@ -149,7 +149,7 @@ def copy_boot_out() -> None:
     _copy_text_file("boot_out.txt")
 
 
-def get_board_ids_from_git() -> List[str]:
+def get_board_ids_from_git() -> list[str]:
     """Get a list of board IDs from the sandbox git repository."""
     ports_path = pathlib.Path("tests/sandbox/circuitpython")
     board_paths = ports_path.glob("ports/*/boards/*")
@@ -172,13 +172,13 @@ def with_token(token: str, use_monkeypatch: bool = False) -> None:
         return prev_token
 
     def with_token_set(func: Callable) -> None:
-        def with_token_set_wrapper(*args: Any, **kwargs: Dict[str, Any]) -> None:
+        def with_token_set_wrapper(*args: Any, **kwargs: dict[str, Any]) -> None:
             prev_token = set_token(token)
             func(*args, **kwargs)
             set_token(prev_token)
 
         def with_token_set_wrapper_monkeypatch(
-            monkeypatch: pytest.MonkeyPatch, *args: Any, **kwargs: Dict[str, Any]
+            monkeypatch: pytest.MonkeyPatch, *args: Any, **kwargs: dict[str, Any]
         ) -> None:
             prev_token = set_token(token)
             func(monkeypatch, *args, **kwargs)


### PR DESCRIPTION
- **Fix path separators for Windows in Makefile**
- **Drop ongoing support for CPython3.8**
- **Use chmod to change perrmissions of files before deleting**
- **Update typing for Python 3.9**
- **Update requirements**
- **Update sphinx config file**
- **Update pre-commit hooks**
- **FIx issue with combining lists**
